### PR TITLE
Inline pqxx type_name variables

### DIFF
--- a/include/pgvector/pqxx.hpp
+++ b/include/pgvector/pqxx.hpp
@@ -21,7 +21,7 @@
 /// @cond
 
 namespace pqxx {
-template <> std::string const type_name<pgvector::Vector>{"vector"};
+template <> inline std::string const type_name<pgvector::Vector>{"vector"};
 
 template <> struct nullness<pgvector::Vector> : pqxx::no_null<pgvector::Vector> {};
 
@@ -66,7 +66,7 @@ template <> struct string_traits<pgvector::Vector> {
     }
 };
 
-template <> std::string const type_name<pgvector::HalfVector>{"halfvec"};
+template <> inline std::string const type_name<pgvector::HalfVector>{"halfvec"};
 
 template <> struct nullness<pgvector::HalfVector> : pqxx::no_null<pgvector::HalfVector> {};
 
@@ -111,7 +111,7 @@ template <> struct string_traits<pgvector::HalfVector> {
     }
 };
 
-template <> std::string const type_name<pgvector::SparseVector>{"sparsevec"};
+template <> inline std::string const type_name<pgvector::SparseVector>{"sparsevec"};
 
 template <> struct nullness<pgvector::SparseVector> : pqxx::no_null<pgvector::SparseVector> {};
 


### PR DESCRIPTION
avoids ODR violations and makes library much easier to integrate into larger projects. 